### PR TITLE
DAT-88: Adding the email address for Lead object

### DIFF
--- a/models/base/salesforce/base_student_marketshare_agent_list.sql
+++ b/models/base/salesforce/base_student_marketshare_agent_list.sql
@@ -15,7 +15,8 @@ WITH active_customers AS (
         'Account' AS sf_object,
         NULL AS phone,
         NULL as competitor,
-        typ.record_type
+        typ.record_type,
+        NULL AS email
     FROM
         {{ ref ('staging_salesforce_account')}} acc
         LEFT JOIN {{ ref('staging_salesforce_record_types') }} typ ON acc.record_type_id = typ.id
@@ -41,7 +42,8 @@ active_opps AS (
         'Opportunity' AS sf_object,
         NULL AS phone,
         opp.competitor,
-        typ.record_type
+        typ.record_type,
+        NULL AS email
     FROM
         {{ ref ('staging_salesforce_opportunity')}} opp
         LEFT JOIN {{ ref ('staging_salesforce_account')}} acc ON opp.account_id = acc.id
@@ -82,7 +84,8 @@ valid_leads AS (
         'Lead' AS sf_object,
         lea.phone,
         lea.competitor,
-        typ.record_type
+        typ.record_type,
+        lea.email
     FROM
          {{ ref ('staging_salesforce_lead')}} lea
          LEFT JOIN {{ ref('staging_salesforce_record_types') }} typ ON lea.record_type_id = typ.id

--- a/models/base/salesforce/base_student_marketshare_agent_list.yml
+++ b/models/base/salesforce/base_student_marketshare_agent_list.yml
@@ -27,3 +27,11 @@ models:
   - name: sf_object
     description: The Salesforce object type, indicating whether the record is an 'Account',
       'Opportunity', or 'Lead'.
+  - name: phone
+    description: The current phone number of the 'Lead' object record.
+  - name: competitor
+    description: The current stated competitor of the 'Opportunity' or 'Lead' object record.
+  - name: record_type
+    description: The associated record type of the salesforce object.
+  - name: email
+    description: The current email address of the 'Lead' object.

--- a/models/staging/salesforce/staging_salesforce_lead.sql
+++ b/models/staging/salesforce/staging_salesforce_lead.sql
@@ -11,7 +11,8 @@
         main_contact_c AS main_contact,
         status,
         phone,
-        competitor_name_c AS competitor
+        competitor_name_c AS competitor,
+        email
     FROM
         {{ source('salesforce', 'lead') }}
     WHERE

--- a/models/staging/salesforce/staging_salesforce_lead.yml
+++ b/models/staging/salesforce/staging_salesforce_lead.yml
@@ -27,3 +27,5 @@ models:
     description: Phone number of the lead.
   - name: competitor
     description: Name of the main competitor for the lead
+  - name: email
+    description: Current email address of the lead.


### PR DESCRIPTION
### Summary

The Account and Opportunity objects utilise a separate join to the Contact object outside of the current base model for market share, Lead requires the address stated on the record itself.


### Detail

1. Added `<email>` to **staging_salesforce_lead.sql**.
2. Updated the **staging_salesforce_lead.yml** file with the new field.

### Additional

1. Updated the **base_student_marketshare_agent_list.yml** file with the additional fields added in previous PR's to reflect the current models field list.