### PR TITLE
DAT-88: Adding Stage for Opportunity records [18/07/2025 12:00]

### DIFF
--- a/models/base/salesforce/base_student_marketshare_agent_list.sql
+++ b/models/base/salesforce/base_student_marketshare_agent_list.sql
@@ -16,7 +16,8 @@ WITH active_customers AS (
         NULL AS phone,
         NULL as competitor,
         typ.record_type,
-        NULL AS email
+        NULL AS email,
+        NULL AS stage,
     FROM
         {{ ref ('staging_salesforce_account')}} acc
         LEFT JOIN {{ ref('staging_salesforce_record_types') }} typ ON acc.record_type_id = typ.id
@@ -43,7 +44,8 @@ active_opps AS (
         NULL AS phone,
         opp.competitor,
         typ.record_type,
-        NULL AS email
+        NULL AS email,
+        opp.stage_name AS stage
     FROM
         {{ ref ('staging_salesforce_opportunity')}} opp
         LEFT JOIN {{ ref ('staging_salesforce_account')}} acc ON opp.account_id = acc.id
@@ -85,7 +87,8 @@ valid_leads AS (
         lea.phone,
         lea.competitor,
         typ.record_type,
-        lea.email
+        lea.email,
+        NULL AS stage
     FROM
          {{ ref ('staging_salesforce_lead')}} lea
          LEFT JOIN {{ ref('staging_salesforce_record_types') }} typ ON lea.record_type_id = typ.id

--- a/models/base/salesforce/base_student_marketshare_agent_list.yml
+++ b/models/base/salesforce/base_student_marketshare_agent_list.yml
@@ -35,3 +35,5 @@ models:
     description: The associated record type of the salesforce object.
   - name: email
     description: The current email address of the 'Lead' object.
+  - name: stage
+    description: The stage field for the 'Opportunity' object records.


### PR DESCRIPTION
### Summary

Nick requested that we be able to filter on the Opportunity Stage in the BDE dashboard, the stage name field needs adding to the model.

### Detail

1. Added the `<stage>` field to the `base_student_marketshare_agent_list.sql`.
2. Updated the `base_student_marketshare_agent_list.yml` file with the new field.