### PR TITLE
DAT-98 | Adding additional staging models for Tableau use.

### DIFF
--- a/models/base/calendar/base_calendar_dates.sql
+++ b/models/base/calendar/base_calendar_dates.sql
@@ -1,0 +1,7 @@
+select
+    date,
+    lettings_year,
+    tenancy_year,
+    financial_year
+from
+    {{ ref('staging_calendar_dates') }}

--- a/models/base/calendar/base_calendar_dates.yml
+++ b/models/base/calendar/base_calendar_dates.yml
@@ -1,0 +1,13 @@
+models:
+- name: base_calendar_dates
+  description: This model provides a foundational view of calendar dates, including
+    various fiscal year categorizations, to support time-based analyses and reporting.
+  columns:
+  - name: date
+    description: The specific calendar date.
+  - name: lettings_year
+    description: The year associated with property lettings.
+  - name: tenancy_year
+    description: The year associated with tenancy agreements.
+  - name: financial_year
+    description: The fiscal year for financial reporting purposes.

--- a/models/base/locations/base_locations_postcodes.sql
+++ b/models/base/locations/base_locations_postcodes.sql
@@ -1,0 +1,5 @@
+select 
+    postcode,
+    latitude,
+    longitude 
+from {{ ref("staging_locations_postcodes") }}

--- a/models/base/locations/base_locations_postcodes.yml
+++ b/models/base/locations/base_locations_postcodes.yml
@@ -1,0 +1,6 @@
+models:
+- name: base_locations_postcodes
+  description: This model serves as a foundational layer for location and postcode
+    data, pulling all columns from the staging_locations_postcodes model. It is used
+    to provide a comprehensive dataset of location and postcode information for further
+    analysis and reporting.

--- a/models/staging/calendar/_sources__calendar.yml
+++ b/models/staging/calendar/_sources__calendar.yml
@@ -1,0 +1,9 @@
+version: 2
+
+sources:
+  - name: calendar
+    database: pc_fivetran_db
+    schema: calendar
+    description: This is a schema containing dates and key periods.
+    tables:
+      - name: dates

--- a/models/staging/calendar/staging_calendar_dates.sql
+++ b/models/staging/calendar/staging_calendar_dates.sql
@@ -1,0 +1,7 @@
+select
+    calendar_date as date,
+    calendar_lettings_year as lettings_year,
+    calendar_tenancy_year as tenancy_year,
+    calendar_financial_year as financial_year
+from
+    {{ source('calendar', 'dates') }}

--- a/models/staging/locations/_locations__sources.yml
+++ b/models/staging/locations/_locations__sources.yml
@@ -1,0 +1,9 @@
+version: 2
+
+sources:
+  - name: locations
+    database: pc_fivetran_db
+    schema: locations
+    description: This is a schema for postcode data for the United Kingdom.
+    tables:
+      - name: uk_postcodes

--- a/models/staging/locations/staging_locations_postcodes.sql
+++ b/models/staging/locations/staging_locations_postcodes.sql
@@ -1,0 +1,5 @@
+select
+    postcode,
+    latitude,
+    longitude 
+from {{ source("locations", "uk_postcodes") }}


### PR DESCRIPTION
### Summary

The current UK Postcode & Calendar data is within the PC_FIVETRAN_DB in Snowflake, this could do with being with the DATA_AND_ANALYTICS_DEV database when we are building our Tableau dashboards.

### Detail

1. New folders added the `staging `folder for `locations `and `calendar`.
2. Added staging .yml and .sql files for locations and calendar data.
3. Added base .yml and .sql files for locations and calendar data.

### Considerations

The calendar data table was a manual creation using Excel, there may be better alternatives such as the DBT package [dbt_date](https://hub.getdbt.com/godatadriven/dbt_date/latest/#:~:text=dbt%2Ddate%20is%20an%20extension,date%20logic%20and%20calendar%20functionality.)
