### PR TITLE
DAT-80 | Adding Dates for Market Share Growth

### DIFF
--- a/models/base/salesforce/base_student_marketshare_agent_list.sql
+++ b/models/base/salesforce/base_student_marketshare_agent_list.sql
@@ -18,6 +18,7 @@ WITH active_customers AS (
         typ.record_type,
         NULL AS email,
         NULL AS stage,
+        DATE(date_won) AS source_date
     FROM
         {{ ref ('staging_salesforce_account')}} acc
         LEFT JOIN {{ ref('staging_salesforce_record_types') }} typ ON acc.record_type_id = typ.id
@@ -45,7 +46,8 @@ active_opps AS (
         opp.competitor,
         typ.record_type,
         NULL AS email,
-        opp.stage_name AS stage
+        opp.stage_name AS stage,
+        DATE(opp.created_date) AS source_date
     FROM
         {{ ref ('staging_salesforce_opportunity')}} opp
         LEFT JOIN {{ ref ('staging_salesforce_account')}} acc ON opp.account_id = acc.id
@@ -88,7 +90,8 @@ valid_leads AS (
         lea.competitor,
         typ.record_type,
         lea.email,
-        NULL AS stage
+        NULL AS stage,
+        DATE(lea.created_date) AS source_date
     FROM
          {{ ref ('staging_salesforce_lead')}} lea
          LEFT JOIN {{ ref('staging_salesforce_record_types') }} typ ON lea.record_type_id = typ.id

--- a/models/staging/salesforce/staging_salesforce_lead.sql
+++ b/models/staging/salesforce/staging_salesforce_lead.sql
@@ -12,7 +12,8 @@
         status,
         phone,
         competitor_name_c AS competitor,
-        email
+        email,
+        created_date
     FROM
         {{ source('salesforce', 'lead') }}
     WHERE

--- a/models/staging/salesforce/staging_salesforce_opportunity.sql
+++ b/models/staging/salesforce/staging_salesforce_opportunity.sql
@@ -6,7 +6,8 @@ SELECT
     account_id,
     stage_name,
     competitor_name_c AS competitor,
-    record_type_id
+    record_type_id,
+    created_date
 FROM 
     {{ source('salesforce', 'opportunity') }}
 WHERE


### PR DESCRIPTION
### Summary

For an executive level view of market share, it would be useful to show growth over time, therefore we need relevant dates to compare as a whole.

### Detail

1. Added dates to each reference object on the `models/base/salesforce/base_student_marketshare_agent_list.sql` model.